### PR TITLE
Solidity constructor should be without visibility modifier

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -5,6 +5,12 @@
       "error",
       "^0.8.9"
     ],
-    "no-empty-blocks": "off"
+    "no-empty-blocks": "off",
+    "func-visibility": [
+      "warn",
+      {
+        "ignoreConstructors": true
+      }
+    ]
   }
 }

--- a/contracts/SDSToken.sol
+++ b/contracts/SDSToken.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract SDSToken is ERC20 {
-    constructor() public ERC20("SDSToken", "SDS") {}
+    constructor() ERC20("SDSToken", "SDS") {}
 
     // Note: this function is only for testing purposes
     function mint500(address to) public {


### PR DESCRIPTION
It is not recommended to add a visibility modifier to constructors in Solidity (>= 0.7.0), so this PR suppresses this warning for constructors.